### PR TITLE
shaders: sync texcoord types between osgtexture2DArray.frag osgtextur…

### DIFF
--- a/shaders/osgtexture2DArray.frag
+++ b/shaders/osgtexture2DArray.frag
@@ -1,7 +1,7 @@
 #extension GL_EXT_texture_array : enable
 
 uniform sampler2DArray texture;
-varying vec4 texcoord;
+varying vec3 texcoord;
 
 
 void main(void)


### PR DESCRIPTION
running the osg example 'osgtexture2DArray' I was getting the following error:
```
~$ osgtexture2DArray
Assigned all images to Texture2DArray separately.
glLinkProgram 0x7f596c027aa0"" FAILED
Program "" infolog:
error: vertex shader output `texcoord' declared as type `vec3', but fragment shader input declared as type `vec4'

Warning: detected OpenGL error 'invalid operation' at after pcp->apply(Unfiorm&) in GLObjectsVisitor::apply(osg::StateSet& stateset), unifrom name:  texture
```
Example works with both switched to vec3 or vec4. I guessed and switched to Vec3. Maybe they should be Vec4?